### PR TITLE
Replace percent signs with url code

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -41,7 +41,7 @@
                 <img class="svg" src="{{ "/assets/images/github.svg" | relative_url }}" title="Contribute" alt="Github Page">
             </a>
             {% else %}
-            <a href="https://github.com/kotor-speedruns/kotor-speedruns.github.io/blob/main/{{ page.path }}">
+            <a href="https://github.com/kotor-speedruns/kotor-speedruns.github.io/blob/main/{{ page.path | replace: '%', '%25'}}">
                 <img class="svg" src="{{ "/assets/images/github.svg" | relative_url }}" title="Contribute" alt="Github Page">
             </a>
             {% endif %}


### PR DESCRIPTION
We were having an issue where the generated Github links were mangling the `%` signs in the uri.

I used liquid's replace feature to resolve this.