### PR TITLE
Coordinate warp guide

### DIFF
--- a/kotor1/Major Glitches/Anywhere Menu Glitch.md
+++ b/kotor1/Major Glitches/Anywhere Menu Glitch.md
@@ -176,6 +176,7 @@ This method of performing a Menu Glitch predated the Anywhere Menu Glitch, but i
 - [Fast Lane](<Fast Lane>)
 - [Fake Level Up](<Fake Level Up>)
 - [The Routine](<The Routine>)
+- [Spawn Warps](<Spawn Warps>)
 - [Gather Party Warps](<../Techniques/GP Warp>)
 - [Save Buffers](<../Techniques/Save Buffering>)
 - [Force Skips](<../Techniques/Force Skips>)

--- a/kotor1/Major Glitches/Hotshot.md
+++ b/kotor1/Major Glitches/Hotshot.md
@@ -12,6 +12,7 @@
 - [Hard Save Hotshots](#hard-save-hotshots)
   - [Via Load Menu](#via-load-menu)
   - [Via Main Menu](#via-main-menu)
+- [Autosave Hotshots](#autosave-hotshots)
 - [Swoop Skips](#swoop-skips)
 - [Uses](#uses)
 - [Related Glitches](#related-glitches)
@@ -177,6 +178,36 @@ This was the original form of Hotshot, and is slower and more complicated than a
 - It is important for the [AMG](<Anywhere Menu Glitch>) to be done via Quick Save in the Destination Module.  We need to store the Teleport save in a Quick Save for the Hotshot to work.
 - Hard Save Hotshots are used twice in [All Quests](<../Route Guides/All Quests Unrestricted>) to warp while spawning party members near the Teleport save location.  In any other situation, [Neo Hotshots](#neo-hotshots) or [Quick Save Hotshots](#quick-save-hotshots) should be used instead.
 
+## Autosave Hotshots
+
+**Description:** Autosave Hotshots are a special method of Hotshot that loads an Autosave that has been saved over.  It has some useful special properties (in particular enabling [Default Spawn Warps](<Spawn Warps#autosave-hotshots>)) but is extremely situational.
+
+**Save Setup:**
+
+- Have an Autosave at the Destination Module
+- Have any save (or actually be) in the Start Module.  This should be near a module transition that Autosaves the game, but it does not have to be the same Autosave as in the Destination Module.
+
+**Steps:**
+
+1. Obtain an [AMG](<Anywhere Menu Glitch>) in the Start Module through either a Quick Save or a module transition.  Loading a Hard Save will not allow you to unpause.
+2. Open the Options Menu and ensure 'Load Game' and 'Cancel' are highlighted.
+3. Press 'Enter'.  This cancels the pop-up and opens the Load Game menu.
+4. Unpause the game, then walk blindly into the module transition.
+5. After the load, the Load Game Menu should still be there.  Use this to load the Autosave.
+
+<div class="video-container">
+    <iframe title="YouTube video player" src="https://www.youtube.com/embed/XQrJdm3TRt8" frameborder="0"></iframe>
+</div>
+
+**Special Properties:**
+
+- This method of Hotshot works by loading an Autosave that has been overwritten.
+- The Autosave Hotshot is the only method of Hotshot that allows you to warp to a module that is not currently in your save file (either due to deletion or merely because it is unvisited).
+- Your party that spawns in the Destination Module is the party that triggered the Start Module Autosave.  This includes party statistics, character build, inventory and quest progress.  *The Destination Module Autosave party info is lost, so you can lose quest progress when performing an Autosave Hotshot.*
+- Your party will spawn in the default spawn location for the module.  This is sometimes called a [Default Spawn Warp](<Spawn Warps#autosave-hotshots>).
+- A modified form of Autosave Hotshot is used to perform the [Transit Point Storage](<Spawn Warps#transit-point-storage>) glitch.  This causes your party to spawn at the most recent transit point in that module instead of the default spawn location.
+- An Autosave Hotshot can be used to bring Trask off the Endar Spire to any other location.
+
 ## Swoop Skips
 
 Swoop Skips are a method for exiting swoop races early in [All Quests](<../Route Guides/All Quests Unrestricted>) runs, thus saving the time of actually doing the races.  The fastest version of the skip uses a [Neo Hotshot](#neo-hotshots), but it can also use a modified [Hard Save Hotshot](#hard-save-hotshots).  The fastest version follows these steps:
@@ -205,9 +236,11 @@ In addition to [Coordinate Warps](<Coordinate Warps>), Hotshots are used many ti
 2. Used to skip the Leviathan in [All Star Maps](<../Route Guides/All Star Maps>) by avoiding flying the Ebon Hawk while in possession of four Star Maps.
 3. Used to skip Ship Parts on Lehon in all Unrestricted speedruns.
 4. Swoop Skips are used to skip all six races on Tatooine and Manaan in [All Quests](<../Route Guides/All Quests Unrestricted>).
+5. Autosave Hotshots are used to perform [Default Spawn Warps](<Spawn Warps#autosave-hotshots>) in all Unrestricted speedruns.
 
 ## Related Glitches
 
 - [Anywhere Menu Glitch](<Anywhere Menu Glitch>)
 - [Coordinate Warps](<Coordinate Warps>)
-- [Autosave Hotshots](<Spawn Warps#autosave-hotshots>)
+- [Default Spawn Warps](<Spawn Warps#default-spawn-warps>)
+- [Transit Point Storage](<Spawn Warps#transit-point-storage>)

--- a/kotor1/Major Glitches/Hotshot.md
+++ b/kotor1/Major Glitches/Hotshot.md
@@ -199,14 +199,18 @@ This was the original form of Hotshot, and is slower and more complicated than a
     <iframe title="YouTube video player" src="https://www.youtube.com/embed/XQrJdm3TRt8" frameborder="0"></iframe>
 </div>
 
-**Special Properties:**
+**Notes:**
 
-- This method of Hotshot works by loading an Autosave that has been overwritten.
-- The Autosave Hotshot is the only method of Hotshot that allows you to warp to a module that is not currently in your save file (either due to deletion or merely because it is unvisited).
-- Your party that spawns in the Destination Module is the party that triggered the Start Module Autosave.  This includes party statistics, character build, inventory and quest progress.  *The Destination Module Autosave party info is lost, so you can lose quest progress when performing an Autosave Hotshot.*
+- The Autosave Hotshot is unlike other Hotshots in almost every way.  The only similarity is in the mechanics of loading a save that has been overwritten.
+- The Autosave Hotshot is the only method of Hotshot that allows you to warp to a module that is not currently in your Start Module save file (either due to deletion or merely because it is unvisited).
+- Due to the nature of Autosave, the Autosave Hotshot can only be used in modules that force an Autosave to occur.  See the list of modules with [Forced Autosaves](<Spawn Warps#forced-autosaves>).
+- An Autosave Hotshot can be used to bring Trask off the Endar Spire to any other location, though this is sadly not useful in a speedrun context.
+
+**Party Spawn Info:**
+
+- Your party that spawns in the Destination Module is the party that triggered the Start Module Autosave.  This includes party statistics, character build, inventory and quest progress.  ***The Destination Module Autosave party info is lost, so you can lose quest progress when performing an Autosave Hotshot.***
 - Your party will spawn in the default spawn location for the module.  This is sometimes called a [Default Spawn Warp](<Spawn Warps#autosave-hotshots>).
-- A modified form of Autosave Hotshot is used to perform the [Transit Point Storage](<Spawn Warps#transit-point-storage>) glitch.  This causes your party to spawn at the most recent transit point in that module instead of the default spawn location.
-- An Autosave Hotshot can be used to bring Trask off the Endar Spire to any other location.
+- A modified form of Autosave Hotshot can be used to perform the [Transit Point Storage](<Spawn Warps#transit-point-storage>) glitch.
 
 ## Swoop Skips
 

--- a/kotor1/Major Glitches/Hotshot.md
+++ b/kotor1/Major Glitches/Hotshot.md
@@ -9,11 +9,9 @@
 - [Hotshot Details](#hotshot-details)
 - [Neo Hotshots](#neo-hotshots)
 - [Quick Save Hotshots](#quick-save-hotshots)
-- [Autosave Hotshots](#autosave-hotshots)
 - [Hard Save Hotshots](#hard-save-hotshots)
   - [Via Load Menu](#via-load-menu)
   - [Via Main Menu](#via-main-menu)
-- [Transit Point Storage](#transit-point-storage)
 - [Swoop Skips](#swoop-skips)
 - [Uses](#uses)
 - [Related Glitches](#related-glitches)
@@ -36,7 +34,7 @@ Save files are made up of a bunch of smaller saves called modules. Usually, we c
 
 - The Main Character (MC) spawns in their last location in the module.
 - Party members will spawn in the same coordinates they were in before the warp, provided they are not out of bounds.  This leads to a technique called [Coordinate Warps](<Coordinate Warps>).
-- The MC is reverted back to the stats, EXP, alignment and equipment they had when they were last in that module.  This can easily lose character progress, so be careful.  This does not apply to [Autosave Hotshots](#autosave-hotshots).
+- The MC is reverted back to the stats, EXP, alignment and equipment they had when they were last in that module.  This can easily lose character progress, so be careful.
 - Party member characteristics are *not* reverted in any way.
 - We keep all inventory items, quest progress, module progressions, and global variable progress between warps.
 
@@ -110,40 +108,6 @@ Neo Hotshots, sometimes called HSS Hotshots, are always consistent and the faste
 - If you obtained [AMG](<Anywhere Menu Glitch>) by entering the Start Module, you can Quick Save in step 4 without closing the Options Menu first.
 - Instead of steps 5,6, and 8, you can load the Quick Save using the mouse.  This is nearly always slower than using the keyboard as described.
 
-## Autosave Hotshots
-
-**Description:** Autosave Hotshots are a special method that loads an Autosave that has been saved over.  It has some useful special properties but is extremely situational.
-
-**Save Setup:**
-
-- Have an Autosave at the Destination Module
-- Have any save (or actually be) in the Start Module.  This should be near a module transition that Autosaves the game, but it does not have to be the same Autosave as in the Destination Module.
-
-**Steps:**
-
-1. Obtain an [AMG](<Anywhere Menu Glitch>) in the Start Module through either a Quick Save or a module transition.  Loading a Hard Save will not allow you to unpause.
-2. Open the Options Menu and ensure 'Load Game' and 'Cancel' are highlighted.
-3. Press 'Enter'.  This cancels the pop-up and opens the Load Game menu.
-4. Unpause the game, then walk blindly into the module transition.
-5. After the load, the Load Game Menu should still be there.  Use this to load the Autosave.
-
-<div class="video-container">
-    <iframe title="YouTube video player" src="https://www.youtube.com/embed/XQrJdm3TRt8" frameborder="0"></iframe>
-</div>
-
-**Special Properties:**
-
-- This method of Hotshot works by loading an Autosave that has been overwritten.
-- The Autosave Hotshot is the only method of Hotshot that allows you to warp to a module that is not currently in your save file (either due to deletion or merely because it is unvisited).
-- The Autosave Hotshot also does not revert your Main Character's stats, equipment, alignment, or experience.
-- An Autosave Hotshot can be used to bring Trask off the Endar Spire to any other location.
-
-**Spawn Location Notes:**
-
-- You will spawn in the Destination Module Autosave, but with the file that walked through the Start Module Autosave.  This includes party, character build, inventory and quest progress.
-- With one possible exception, you will spawn in the default spawn location for the module.  This is sometimes called a Default Spawn Warp.
-- The exception is if you have previously used Return to Hideout/Ebon Hawk in the Destination Module, and use the [Transit Point Storage](#transit-point-storage) glitch described below.  Then you will spawn at the most recent transit point in that module, even if you have since created other transit points in other modules.
-
 ## Hard Save Hotshots
 
 Hard Save Hotshots were the original form of Hotshots, and are somewhat misnamed, since they actually load a Hard Save as a Quick Save.  This type of Hotshot is *not* consistent, and thus has been almost entirely obsoleted by the consistent methods of hotshot, [Neo Hotshots](#neo-hotshots) and [Quick Save Hotshots](#quick-save-hotshots).  There are two ways to perform this type of Hotshot, but both share the same save setup.
@@ -208,44 +172,10 @@ This was the original form of Hotshot, and is slower and more complicated than a
 
 **Additional Notes:**
 
-- Hard Save Hotshots have two unique uses over other Hotshot methods:
-
-  1. Spawning OoB party members at the Teleport save location, rather than the MC's location.
-  2. [Swoop Skips](#swoop-skips) can only be done with either a Hard Save Hotshot or an [Neo Hotshot](#neo-hotshots), as you cannot load a save in the swoop race modules (and they do not have Autosaves).
-
+- Hard Save Hotshots have one niche effect that gives them a use in speedruns: OoB party members spawn at the Teleport save location, rather than the MC's location.
 - Notice that Hard Save Hotshots are not entirely consistent.  It may take several tries for the Hotshot Current save to change to QUICKSAVE, though that is unusual.
 - It is important for the [AMG](<Anywhere Menu Glitch>) to be done via Quick Save in the Destination Module.  We need to store the Teleport save in a Quick Save for the Hotshot to work.
 - Hard Save Hotshots are used twice in [All Quests](<../Route Guides/All Quests Unrestricted>) to warp while spawning party members near the Teleport save location.  In any other situation, [Neo Hotshots](#neo-hotshots) or [Quick Save Hotshots](#quick-save-hotshots) should be used instead.
-
-## Transit Point Storage
-
-Transit Point Storage is a specialized application of [Autosave Hotshots](#autosave-hotshots), used when you want to return to a specific place in a module even after using fast transit elsewhere.
-
-There are three restrictions:
-
-- Only transit points stored in modules that Autosave upon entry can be warped to.
-- Stored transit points can only be warped to from modules that Autosave upon entry.
-- The Autosave must be in the module with your stored transit point.  This can be accomplished using a Hard Save in an adjacent module.
-
-**Steps:**
-
-1. When you first visit the module, set the transit point where you want to spawn.
-2. When you want to warp to that stored transit point, make sure you are in a module that Autosaves. 
-3. Quick Save your current game and load the save described above.
-4. Go to the module you want to warp to so that the Autosave triggers, then Quick Load.
-5. Return to the Ebon Hawk/Hideout (possibly using a Fast Lane) and activate [AMG](<Anywhere Menu Glitch>) on the load.
-6. Open the map and click Transit Back.  This replaces the Quit pop-up with the Transit Back pop-up.
-7. Switch to the Options Menu and ensure both "OK" and "Load Game" are highlighted using the mouse.
-8. Press Enter.  This transits back to the module you Quick Saved in, triggering an Autosave, and opens the Load Game menu.
-9. After loading in, use the Load Game menu to load the Autosave.
-
-<div class="video-container">
-    <iframe title="YouTube video player" src="https://www.youtube.com/embed/oeJRPTpj1e8" frameborder="0"></iframe>
-</div>
-
-Notice that steps 5-9 are a modified [Autosave Hotshot](#autosave-hotshots).  It uses fast transit to trigger an Autosave while the Load Menu is open, rather than moving through a load zone.
-
-This glitch can be used to store only one transit point per module, but you can store one for every module and travel there as long as the Autosave conditions are met.
 
 ## Swoop Skips
 
@@ -275,10 +205,9 @@ In addition to [Coordinate Warps](<Coordinate Warps>), Hotshots are used many ti
 2. Used to skip the Leviathan in [All Star Maps](<../Route Guides/All Star Maps>) by avoiding flying the Ebon Hawk while in possession of four Star Maps.
 3. Used to skip Ship Parts on Lehon in all Unrestricted speedruns.
 4. Swoop Skips are used to skip all six races on Tatooine and Manaan in [All Quests](<../Route Guides/All Quests Unrestricted>).
-5. Transit Point Storage is used once in [All Quests](<../Route Guides/All Quests Unrestricted>) to warp from Manaan to Tatooine.
-6. [Autosave Hotshots](#autosave-hotshots) are used a few times to spawn at a module's default spawn in all Unrestricted routes.
 
 ## Related Glitches
 
 - [Anywhere Menu Glitch](<Anywhere Menu Glitch>)
 - [Coordinate Warps](<Coordinate Warps>)
+- [Autosave Hotshots](<Spawn Warps#autosave-hotshots>)

--- a/kotor1/Major Glitches/Spawn Warps
+++ b/kotor1/Major Glitches/Spawn Warps
@@ -1,0 +1,3 @@
+# Spawn Warps
+
+Coming soon!

--- a/kotor1/Major Glitches/Spawn Warps
+++ b/kotor1/Major Glitches/Spawn Warps
@@ -1,3 +1,0 @@
-# Spawn Warps
-
-Coming soon!

--- a/kotor1/Major Glitches/Spawn Warps.md
+++ b/kotor1/Major Glitches/Spawn Warps.md
@@ -155,7 +155,7 @@ The following list contains all modules that force an Autosave.  These are modul
 
 ### Unusual Default Spawns
 
-This is a list of all modules that have unusual default spawn locations.  While some module's default spawns are at the usual module transition locations, these spawns are elsewhere and thus may be useful to [Default Spawn Warp](#default-spawn-warps) to.
+This is a list of all modules that have unusual default spawn locations.  While some module's default spawns are at the usual module transition locations, these modules have more interesting default spawns that may make a [Default Spawn Warp](#default-spawn-warps) worthwhile.
 
 *Table coming soon.*
 

--- a/kotor1/Major Glitches/Spawn Warps.md
+++ b/kotor1/Major Glitches/Spawn Warps.md
@@ -1,44 +1,78 @@
 # Spawn Warps
 
+**Table of Contents**
+- [Description](#description)
+- [Default Spawn Warps](#default-spawn-warps)
+  - [Autosave Hotshots](#autosave-hotshots)
+  - [The Routine](#the-routine)
+- [Transit Point Storage](#transit-point-storage)
+- [Uses](#uses)
+- [Module Lists](#module-lists)
+  - [Forced Autosaves](#forced-autosaves)
+  - [Unusual Default Spawns](#unusual-default-spawns)
+- [Related Glitches](#related-glitches)
 
 
-## Autosave Hotshots
+## Description
 
-**Description:** Autosave Hotshots are a special method that loads an Autosave that has been saved over.  It has some useful special properties but is extremely situational.
+Spawn Warps are a class of glitches that cause the party to warp to a specific spawn waypoint within a module.  This can be used to cut out movement or in rare cases skip past otherwise problematic obstacles.
+
+## Default Spawn Warps
+
+Every module has a waypoint inside of it that acts as a default spawn point.  Under certain circumstances, an entry made to the module in a non-standard way (i.e. not by entering from an adjacent module) will cause the entire party to spawn at this default spawn point.  A Default Spawn Warp, therefore, is any method of entering a module in a non-standard way. 
+
+There are currently two methods for warping to the default spawn location of a module; we'll call the module we're warping to the Destination Module.
+
+### Autosave Hotshots
+
+**Description:** Autosave Hotshots are a special method of [Hotshot](<Hotshot>) that loads an Autosave that has been saved over.  It requires a specific save setup, and thus is extremely situational.
 
 **Save Setup:**
 
-- Have an Autosave at the Destination Module
-- Have any save (or actually be) in the Start Module.  This should be near a module transition that Autosaves the game, but it does not have to be the same Autosave as in the Destination Module.
+- Have the Autosave at the Destination Module
 
 **Steps:**
 
-1. Obtain an [AMG](<Anywhere Menu Glitch>) in the Start Module through either a Quick Save or a module transition.  Loading a Hard Save will not allow you to unpause.
-2. Open the Options Menu and ensure 'Load Game' and 'Cancel' are highlighted.
-3. Press 'Enter'.  This cancels the pop-up and opens the Load Game menu.
-4. Unpause the game, then walk blindly into the module transition.
-5. After the load, the Load Game Menu should still be there.  Use this to load the Autosave.
+1. Obtain an [AMG](<Anywhere Menu Glitch>) through either a Quick Save or a module transition.  Loading a Hard Save will not allow you to unpause.
+2. Be near some way of triggering a module transition that will force an Autosave.
+3. Open the Options Menu and ensure 'Load Game' and 'Cancel' are highlighted.
+4. Press 'Enter'.  This cancels the pop-up and opens the Load Game menu.
+5. Unpause the game, then blindly trigger the module transition (either by walking or otherwise).
+6. After the load, the Load Game Menu should still be there.  Use this to load the Autosave.
 
 <div class="video-container">
     <iframe title="YouTube video player" src="https://www.youtube.com/embed/XQrJdm3TRt8" frameborder="0"></iframe>
 </div>
 
-**Special Properties:**
+**Notes:**
 
-- This method of Hotshot works by loading an Autosave that has been overwritten.
-- The Autosave Hotshot is the only method of Hotshot that allows you to warp to a module that is not currently in your save file (either due to deletion or merely because it is unvisited).
-- The Autosave Hotshot also does not revert your Main Character's stats, equipment, alignment, or experience.
+- The Autosave Hotshot is unlike other [Hotshots](<Hotshot>) in almost every way.  The only similarity is in the mechanics of loading a save that has been overwritten.
+- Due to the nature of Autosave, the Autosave Hotshot can only be used in modules that force an Autosave to occur.  See the list of [Forced Autosaves](#forced-autosaves) below.
+- The Destination Module does not have to exist in your current save file.  This is also unlike other [Hotshots](<Hotshot>).
+- Your entire party will spawn together at the default spawn location in the Destination Module, but with the file that walked through the Start Module Autosave.  This includes party, character build, inventory and quest progress.
+- An Autosave Hotshot can be triggered by using fast travel to Transit Back to a module that forces an Autosave.  This can be used to perform [Transit Point Storage](#transit-point-storage).
 - An Autosave Hotshot can be used to bring Trask off the Endar Spire to any other location.
 
-**Spawn Location Notes:**
+### The Routine
 
-- You will spawn in the Destination Module Autosave, but with the file that walked through the Start Module Autosave.  This includes party, character build, inventory and quest progress.
-- With one possible exception, you will spawn in the default spawn location for the module.  This is sometimes called a Default Spawn Warp.
-- The exception is if you have previously used Return to Hideout/Ebon Hawk in the Destination Module, and use the [Transit Point Storage](#transit-point-storage) glitch described below.  Then you will spawn at the most recent transit point in that module, even if you have since created other transit points in other modules.
+**Description:** By using [the Routine](<The Routine>) to delete data from our save file, we can also delete the transit waypoint that we have set in the Destination Module.  Using fast travel to Transit Back after performing a Routine will then return the party to the default spawn location in the Destination Module.
+
+**Steps:**
+1. Reach the Destination Module whose default spawn location you want to reach.
+2. Return to the Hideout/Ebon Hawk.  This can be done either naturally or with a [Fast Lane](<Fast Lane>).
+3. Perform [the Routine](<The Routine>) to delete the Destination Module (and its transit waypoint data) from your save file.
+4. After loading your Quick Save, Transit Back to reach the Destination Module's default spawn location.
+
+*Video forthcoming*
+
+**Notes:**
+
+- Since [the Routine](<The Routine>) deletes most of your save file data, this method of Default Spawn Warp is best used very early in the run.
+- Also note that using [the Routine](<The Routine>) will make Save Teleporting ineffective.
 
 ## Transit Point Storage
 
-Transit Point Storage is a specialized application of [Autosave Hotshots](#autosave-hotshots), used when you want to return to a specific place in a module even after using fast transit elsewhere.
+Transit Point Storage is a specialized application of [Autosave Hotshots](#autosave-hotshots) that allows you to return to a fast travel waypoint in a module, even after using fast transit elsewhere.
 
 There are three restrictions:
 
@@ -62,7 +96,71 @@ There are three restrictions:
     <iframe title="YouTube video player" src="https://www.youtube.com/embed/oeJRPTpj1e8" frameborder="0"></iframe>
 </div>
 
-Notice that steps 5-9 are a modified [Autosave Hotshot](#autosave-hotshots).  It uses fast transit to trigger an Autosave while the Load Menu is open, rather than moving through a load zone.
+**Notes:**
+- Notice that steps 5-9 are a modified [Autosave Hotshot](#autosave-hotshots) using fast transit to trigger an Autosave while the Load Menu is open, rather than moving through a load zone.
+- If no transit point has ever been set in the Destination Module, Transit Point Storage will spawn you at the default spawn location for the module.
 
-This glitch can be used to store only one transit point per module, but you can store one for every module and travel there as long as the Autosave conditions are met.
+This glitch can be used to store only one transit point per module, but you can store one for every module and travel there as long as the Autosave conditions are met.  See [Forced Autosaves](#forced-autosaves) for a list of modules whose transit points can be warped to.
 
+## Uses
+
+[Default Spawn Warps](#default-spawn-warps) are used several times in Unrestricted speedruns:  
+
+- [The Routine](#the-routine) method is used to warp to Upper City South's default spawn location (near Zelka's shop).
+- [Autosave Hotshots](#autosave-hotshots) are used to warp to the following modules:
+    - Upper City North (in all Unrestricted categories)
+    - Lower City (in All Quests)
+    - Dantooine Courtyard (in All Quests)
+    - West Central (in All Star Maps)
+    - Hrakert Rift (in All Star Maps)
+    - Leviathan Command Deck (in All Quests)
+    - Temple Exterior (in Any%)
+ 
+[Transit Point Storage](#transit-point-storage) is used once in All Quests Unrestricted to return to the Dune Sea from Manaan.
+
+## Module Lists
+
+### Forced Autosaves
+
+The following list contains all modules that force an Autosave.  These are modules that are eligible for [Autosave Hotshots](#autosave-hotshots) or [Transit Point Storage](#transit-point-storage).
+
+- Command Module
+- Starboard Section
+- Upper City South
+- Upper City North
+- Lower City
+- Undercity
+- Lower Sewers
+- Vulkar Base
+- Davik's Estate
+- Courtyard
+- Ruins
+- Sandral Estate
+- Great Walkway
+- Upper Shadowlands
+- Sith Academy Entrance
+- Valley of the Dark Lords
+- Anchorhead
+- Dune Sea
+- Eastern Dune Sea
+- West Central
+- Manaan Sith Base
+- Hrakert Station
+- Hrakert Rift
+- Prison Block
+- Command Deck
+- Temple Exterior
+- Temple Main Floor
+- Deck 1
+
+### Unusual Default Spawns
+
+This is a list of all modules that have unusual default spawn locations.  While some module's default spawns are at the usual module transition locations, these spawns are elsewhere and thus may be useful to [Default Spawn Warp](#default-spawn-warps) to.
+
+*Table coming soon.*
+
+## Related Glitches
+
+- [Anywhere Menu Glitch](<Anywhere Menu Glitch>)
+- [Hotshot](<Hotshot>)
+- [The Routine](<The Routine>)

--- a/kotor1/Major Glitches/Spawn Warps.md
+++ b/kotor1/Major Glitches/Spawn Warps.md
@@ -25,29 +25,20 @@ There are currently two methods for warping to the default spawn location of a m
 
 ### Autosave Hotshots
 
-**Description:** This method of Default Spawn Warp uses the property of [Autosave Hotshots](<Hotshot#autosave-hotshots>) that spawns the party at the default spawn location for a module.  Thus any time you use an Autosave Hotshot, you're also doing a Default Spawn Warp.  While still a specialized glitch, it is the more flexible of the two Default Spawn Warp methods.
+**Description:** This method of Default Spawn Warp uses the property of [Autosave Hotshots](<Hotshot#autosave-hotshots>) that spawns the party at the default spawn location for a module.  Thus any time you use an Autosave Hotshot, you're also doing a Default Spawn Warp (unless you're performing [Transit Point Storage](#transit-point-storage).  While still a specialized glitch, Autosave Hotshots are the more flexible of the two Default Spawn Warp methods.
 
 **Steps:**
 
-1. Obtain an [AMG](<Anywhere Menu Glitch>) through either a Quick Save or a module transition.  Loading a Hard Save will not allow you to unpause.
-2. Be near some way of triggering a module transition that will force an Autosave.
-3. Open the Options Menu and ensure 'Load Game' and 'Cancel' are highlighted.
-4. Press 'Enter'.  This cancels the pop-up and opens the Load Game menu.
-5. Unpause the game, then blindly trigger the module transition (either by walking or otherwise).
-6. After the load, the Load Game Menu should still be there.  Use this to load the Autosave.
+1. Have an Autosave in your Destination Module.
+2. Use another Autosave with your desired party to perform an [Autosave Hotshot](<Hotshot#autosave-hotshots>).
 
 <div class="video-container">
     <iframe title="YouTube video player" src="https://www.youtube.com/embed/XQrJdm3TRt8" frameborder="0"></iframe>
 </div>
 
 **Notes:**
-
-- The Autosave Hotshot is unlike other [Hotshots](<Hotshot>) in almost every way.  The only similarity is in the mechanics of loading a save that has been overwritten.
-- Due to the nature of Autosave, the Autosave Hotshot can only be used in modules that force an Autosave to occur.  See the list of [Forced Autosaves](#forced-autosaves) below.
-- The Destination Module does not have to exist in your current save file.  This is also unlike other [Hotshots](<Hotshot>).
-- Your entire party will spawn together at the default spawn location in the Destination Module, but with the file that walked through the Start Module Autosave.  This includes party, character build, inventory and quest progress.
-- An Autosave Hotshot can be triggered by using fast travel to Transit Back to a module that forces an Autosave.  This can be used to perform [Transit Point Storage](#transit-point-storage).
-- An Autosave Hotshot can be used to bring Trask off the Endar Spire to any other location.
+- Remember that the party that spawns in the Destination Module is the one that triggers the Autosave Hotshot.  You can lose quest progress in this way if that party has less progress than the Destination Module autosave party.
+- The only situation in which an [Autosave Hotshot](<Hotshot#autosave-hotshots>) does not spawn the party at the default spawn location is if [Transit Point Storage](#transit-point-storage) is used instead.
 
 ### The Routine
 

--- a/kotor1/Major Glitches/Spawn Warps.md
+++ b/kotor1/Major Glitches/Spawn Warps.md
@@ -161,33 +161,29 @@ This is a list of all modules that have unusual default spawn locations.  While 
 | Taris | Sith Base | In hall outside Assault Droid's room | (36.60, 3.80) |
 | Dantooine | Courtyard | Between Adum Larp and Elise | (163.22, 139.29) |
 | Dantooine | Matale Grounds | In front of Matale Estate | (320.48, 106.54) |
-
-
-manm26ac	West Central		Near Port Authority
-manm27aa	Manaan Sith Base	In room past Steam Vents
-manm28ad	Hrakert Rift		On bridge near Progenitor
-lev_m40aa	Prison Block		In detention cell (Saul CS)
-lev_m40ab	Command Deck		Near doors to Bridge
-unk_m41aa	Temple Exterior		Near Mandalorian fight trigger
-unk_m44aa	Temple Main Floor	In room with two Dark Jedi near Sith Master
-
-danm14ac	Grove			Near Juhani
-danm14ad	Sandral Grounds		In front of Sandral Estate
-korr_m34aa	Shyrack Caves		Near renegade Sith students
-korr_m38ab	Tomb of Tulak Hord	Near ancient console
-lev_m40ac	Hangar			In hall leading to Malak confrontation
-manm26aa	Ahto West		In prison next to Sunry
-manm26ab	Ahto East		At entrance to swoop bar
-manm26ad	Manaan Docking Bay	At end of short hall out of Ebon Hawk dock
-manm26ae	East Central		At Republic Embassy entrance
-manm28ac	Kolto Control		Force field room near scientists
-tat_m17ab	Tatooine Docking Bay	Somewhat closer to Mic'Tunan'Jus Orgu
-tat_m18ab	Sand People Territory	At Eastern Dune Sea entrance
-unk_m41ab	South Beach		In front of Elder Rakata settlement
-unk_m41ac	North Beach		On beach near Warrior Rakata settlement
-unk_m43aa	Rakatan Settlement	In cell with Elder Warrior (can escape with Security FLU)
-unk_m44ab	Temple Catacombs	In front of door leading to puzzle room
-
+| Dantooine | Grove | Near Juhani's ruins | (427.97, 388.46) |
+| Dantooine | Sandral Grounds | In front of Sandral Estate | (335.47, 152,35) |
+| Tatooine | Docking Bay | Behind Czerka Customs Officer | (-6.83, -26.73) |
+| Tatooine | Sand People Territory | In front of Eastern Dune Sea entrance | (311.22, 312.25) |
+| Manaan | Docking Bay | At end of short hall out of Ebon Hawk dock | (252.15, 190.30) |
+| Manaan | West Central | In small room near Selkath Port Official | (-40.48, 65.02) |
+| Manaan | East Central | Just inside Republic Embassy entrance | (66.14, 63.00) |
+| Manaan | Ahto West | In prison next to Sunry's cell | (29.74, 12.33) |
+| Manaan | Ahto East | Just inside entrance to swoop bar | (-86.82, 25.05) |
+| Manaan | Sith Base | In small room past steam vents | (205.71, 110.68) |
+| Manaan | Kolto Control | In depressurization room with force field | (219.06, 105.57) |
+| Manaan | Hrakert Rift | On bridge just in front of the Progenitor | (163.34, 105.25) |
+| Korriban | Shyrack Caves | At mouth of cave with renegade Sith students | (98.51, 108.55) |
+| Korriban | Tomb of Tulak Hord | Right in front of ancient console | (92.17, 74.55) |
+| Leviathan | Prison Block | Inside cell from Saul torture cutscene | (21.25, 44.01) |
+| Leviathan | Command Deck | Right outside door from Leviathan Bridge | (137.20, 54.66) |
+| Leviathan | Hangar | At top of ramp leading to Malak confrontation | (154.16, 154.91) |
+| Unknown Planet | Temple Exterior | Near Mandalorian fight trigger to right of temple | (264.19, 86.21) |
+| Unknown Planet | South Beach | Outside entrance to Elder Rakata settlement | (44.58, 125.22) |
+| Unknown Planet | North Beach | On beach outside Warrior Rakata settlement | (164.64, 182.47) |
+| Unknown Planet | Rakatan Settlement | In cell with Elder Warrior | (49.97, 158.84) |
+| Unknown Planet | Temple Main Floor | In room with two Dark Jedi next to Sith Master | (78.75, 70.10) |
+| Unknown Planet | Temple Catacombs | In front of door to tile puzzle room | (74.92, 79.60) |
 
 ## Related Glitches
 

--- a/kotor1/Major Glitches/Spawn Warps.md
+++ b/kotor1/Major Glitches/Spawn Warps.md
@@ -103,7 +103,7 @@ This glitch can be used to store only one transit point per module, but you can 
     - West Central (in [All Star Maps](<../Route Guides/All Star Maps>))
     - Hrakert Rift (in [All Star Maps](<../Route Guides/All Star Maps>))
     - Leviathan Command Deck (in [All Quests](<../Route Guides/All Quests Unrestricted>))
-    - Temple Exterior (in [Any%](<../Route Guides/Any%25Unrestricted>))
+    - Temple Exterior (in [Any%](<../Route Guides/Any%25 Unrestricted>))
  
 [Transit Point Storage](#transit-point-storage) is used once in All Quests Unrestricted to return to the Dune Sea from Manaan.
 

--- a/kotor1/Major Glitches/Spawn Warps.md
+++ b/kotor1/Major Glitches/Spawn Warps.md
@@ -145,7 +145,49 @@ The following table contains all 28 modules that force an Autosave.  These are m
 
 This is a list of all modules that have unusual default spawn locations.  While some modules' default spawns are at the usual module transition locations, these modules have more interesting default spawns that may make a [Default Spawn Warp](#default-spawn-warps) worthwhile.
 
-*Table coming soon.*
+| **Planet** | **Module** | **Default Spawn Description** | **Coordinates** | 
+|---|---|---|---|
+| Taris | Upper City South | In front of the door to Zelka's medical clinic | (188.06, 80.30) |
+| Taris | Upper City North | Between Gorton Colu and the Lower City elevator | (109.38, 123.36) |
+| Taris | North Apartments | Between Sarna's apartment and the Sith Soldier fight apartment | (90.00, 125.21) |
+| Taris | Upper City Cantina | In doorway between first room and hub | (123.17, 110.00) |
+| Taris | Lower City | In main hall near Lower City Apartments West entrance | (322.53, 221.15) |
+| Taris | Lower City Apartments East | In front of Matrik's apartment | (131.78, 93.41) |
+| Taris | Javyar's Cantina | In front of Zax, the bounty Hutt | (110.00, 79.63) |
+| Taris | Undercity | In front of crashed Republic escape pod | (312.93, 234.66) |
+| Taris | Upper Sewers | On ramp next to severed arm outside rancor room | (215.16, 332.98) |
+| Taris | Vulkar Base | In hall outside mined pool room | (103.29, 115.92) |
+| Taris | Vulkar Garage | Next to Garage Head's Desk | (46.36, 104.77) |
+| Taris | Sith Base | In hall outside Assault Droid's room | (36.60, 3.80) |
+| Dantooine | Courtyard | Between Adum Larp and Elise | (163.22, 139.29) |
+| Dantooine | Matale Grounds | In front of Matale Estate | (320.48, 106.54) |
+
+
+manm26ac	West Central		Near Port Authority
+manm27aa	Manaan Sith Base	In room past Steam Vents
+manm28ad	Hrakert Rift		On bridge near Progenitor
+lev_m40aa	Prison Block		In detention cell (Saul CS)
+lev_m40ab	Command Deck		Near doors to Bridge
+unk_m41aa	Temple Exterior		Near Mandalorian fight trigger
+unk_m44aa	Temple Main Floor	In room with two Dark Jedi near Sith Master
+
+danm14ac	Grove			Near Juhani
+danm14ad	Sandral Grounds		In front of Sandral Estate
+korr_m34aa	Shyrack Caves		Near renegade Sith students
+korr_m38ab	Tomb of Tulak Hord	Near ancient console
+lev_m40ac	Hangar			In hall leading to Malak confrontation
+manm26aa	Ahto West		In prison next to Sunry
+manm26ab	Ahto East		At entrance to swoop bar
+manm26ad	Manaan Docking Bay	At end of short hall out of Ebon Hawk dock
+manm26ae	East Central		At Republic Embassy entrance
+manm28ac	Kolto Control		Force field room near scientists
+tat_m17ab	Tatooine Docking Bay	Somewhat closer to Mic'Tunan'Jus Orgu
+tat_m18ab	Sand People Territory	At Eastern Dune Sea entrance
+unk_m41ab	South Beach		In front of Elder Rakata settlement
+unk_m41ac	North Beach		On beach near Warrior Rakata settlement
+unk_m43aa	Rakatan Settlement	In cell with Elder Warrior (can escape with Security FLU)
+unk_m44ab	Temple Catacombs	In front of door leading to puzzle room
+
 
 ## Related Glitches
 

--- a/kotor1/Major Glitches/Spawn Warps.md
+++ b/kotor1/Major Glitches/Spawn Warps.md
@@ -155,7 +155,7 @@ The following list contains all modules that force an Autosave.  These are modul
 
 ### Unusual Default Spawns
 
-This is a list of all modules that have unusual default spawn locations.  While some module's default spawns are at the usual module transition locations, these modules have more interesting default spawns that may make a [Default Spawn Warp](#default-spawn-warps) worthwhile.
+This is a list of all modules that have unusual default spawn locations.  While some modules' default spawns are at the usual module transition locations, these modules have more interesting default spawns that may make a [Default Spawn Warp](#default-spawn-warps) worthwhile.
 
 *Table coming soon.*
 

--- a/kotor1/Major Glitches/Spawn Warps.md
+++ b/kotor1/Major Glitches/Spawn Warps.md
@@ -122,36 +122,24 @@ This glitch can be used to store only one transit point per module, but you can 
 
 ### Forced Autosaves
 
-The following list contains all modules that force an Autosave.  These are modules that are eligible for [Autosave Hotshots](#autosave-hotshots) or [Transit Point Storage](#transit-point-storage).
+The following table contains all 28 modules that force an Autosave.  These are modules that are eligible for [Autosave Hotshots](#autosave-hotshots) or [Transit Point Storage](#transit-point-storage).
 
-- Command Module
-- Starboard Section
-- Upper City South
-- Upper City North
-- Lower City
-- Undercity
-- Lower Sewers
-- Vulkar Base
-- Davik's Estate
-- Courtyard
-- Ruins
-- Sandral Estate
-- Great Walkway
-- Upper Shadowlands
-- Sith Academy Entrance
-- Valley of the Dark Lords
-- Anchorhead
-- Dune Sea
-- Eastern Dune Sea
-- West Central
-- Manaan Sith Base
-- Hrakert Station
-- Hrakert Rift
-- Prison Block
-- Command Deck
-- Temple Exterior
-- Temple Main Floor
-- Deck 1
+| **Planet** | **Module** | | **Planet** | **Module** |
+|---|---|---|---|---|
+| Endar Spire | Command Module | | Korriban | Sith Academy Entrance |
+| Endar Spire | Starboard Section | | Korriban | Valley of the Dark Lords |
+| Taris | Upper City South | | Tatooine | Anchorhead |
+| Taris | Upper City North | | Tatooine | Dune Sea |
+| Taris | Lower City | | Tatooine | Eastern Dune Sea |
+| Taris | Undercity | | Manaan | West Central |
+| Taris | Lower Sewers | | Manaan | Sith Base |
+| Taris | Vulkar Base | | Manaan | Hrakert Station |
+| Taris | Davik's Estate | | Manaan | Hrakert Rift |
+| Dantooine | Courtyard | | Leviathan | Prison Block |
+| Dantooine | Ruins | | Leviathan | Command Deck |
+| Dantooine | Sandral Estate | | Unknown Planet | Temple Exterior |
+| Kashyyyk | Great Walkway | | Unknown Planet | Temple Main Floor |
+| Kashyyyk | Upper Shadowlands | | Star Forge | Deck 1 |
 
 ### Unusual Default Spawns
 

--- a/kotor1/Major Glitches/Spawn Warps.md
+++ b/kotor1/Major Glitches/Spawn Warps.md
@@ -1,0 +1,68 @@
+# Spawn Warps
+
+
+
+## Autosave Hotshots
+
+**Description:** Autosave Hotshots are a special method that loads an Autosave that has been saved over.  It has some useful special properties but is extremely situational.
+
+**Save Setup:**
+
+- Have an Autosave at the Destination Module
+- Have any save (or actually be) in the Start Module.  This should be near a module transition that Autosaves the game, but it does not have to be the same Autosave as in the Destination Module.
+
+**Steps:**
+
+1. Obtain an [AMG](<Anywhere Menu Glitch>) in the Start Module through either a Quick Save or a module transition.  Loading a Hard Save will not allow you to unpause.
+2. Open the Options Menu and ensure 'Load Game' and 'Cancel' are highlighted.
+3. Press 'Enter'.  This cancels the pop-up and opens the Load Game menu.
+4. Unpause the game, then walk blindly into the module transition.
+5. After the load, the Load Game Menu should still be there.  Use this to load the Autosave.
+
+<div class="video-container">
+    <iframe title="YouTube video player" src="https://www.youtube.com/embed/XQrJdm3TRt8" frameborder="0"></iframe>
+</div>
+
+**Special Properties:**
+
+- This method of Hotshot works by loading an Autosave that has been overwritten.
+- The Autosave Hotshot is the only method of Hotshot that allows you to warp to a module that is not currently in your save file (either due to deletion or merely because it is unvisited).
+- The Autosave Hotshot also does not revert your Main Character's stats, equipment, alignment, or experience.
+- An Autosave Hotshot can be used to bring Trask off the Endar Spire to any other location.
+
+**Spawn Location Notes:**
+
+- You will spawn in the Destination Module Autosave, but with the file that walked through the Start Module Autosave.  This includes party, character build, inventory and quest progress.
+- With one possible exception, you will spawn in the default spawn location for the module.  This is sometimes called a Default Spawn Warp.
+- The exception is if you have previously used Return to Hideout/Ebon Hawk in the Destination Module, and use the [Transit Point Storage](#transit-point-storage) glitch described below.  Then you will spawn at the most recent transit point in that module, even if you have since created other transit points in other modules.
+
+## Transit Point Storage
+
+Transit Point Storage is a specialized application of [Autosave Hotshots](#autosave-hotshots), used when you want to return to a specific place in a module even after using fast transit elsewhere.
+
+There are three restrictions:
+
+- Only transit points stored in modules that Autosave upon entry can be warped to.
+- Stored transit points can only be warped to from modules that Autosave upon entry.
+- The Autosave must be in the module with your stored transit point.  This can be accomplished using a Hard Save in an adjacent module.
+
+**Steps:**
+
+1. When you first visit the module, set the transit point where you want to spawn.
+2. When you want to warp to that stored transit point, make sure you are in a module that Autosaves. 
+3. Quick Save your current game and load the save described above.
+4. Go to the module you want to warp to so that the Autosave triggers, then Quick Load.
+5. Return to the Ebon Hawk/Hideout (possibly using a Fast Lane) and activate [AMG](<Anywhere Menu Glitch>) on the load.
+6. Open the map and click Transit Back.  This replaces the Quit pop-up with the Transit Back pop-up.
+7. Switch to the Options Menu and ensure both "OK" and "Load Game" are highlighted using the mouse.
+8. Press Enter.  This transits back to the module you Quick Saved in, triggering an Autosave, and opens the Load Game menu.
+9. After loading in, use the Load Game menu to load the Autosave.
+
+<div class="video-container">
+    <iframe title="YouTube video player" src="https://www.youtube.com/embed/oeJRPTpj1e8" frameborder="0"></iframe>
+</div>
+
+Notice that steps 5-9 are a modified [Autosave Hotshot](#autosave-hotshots).  It uses fast transit to trigger an Autosave while the Load Menu is open, rather than moving through a load zone.
+
+This glitch can be used to store only one transit point per module, but you can store one for every module and travel there as long as the Autosave conditions are met.
+

--- a/kotor1/Major Glitches/Spawn Warps.md
+++ b/kotor1/Major Glitches/Spawn Warps.md
@@ -1,4 +1,4 @@
-# Default Spawn Warps
+# Spawn Warps
 
 **Table of Contents**
 - [Description](#description)

--- a/kotor1/Major Glitches/Spawn Warps.md
+++ b/kotor1/Major Glitches/Spawn Warps.md
@@ -9,7 +9,7 @@
 - [Uses](#uses)
 - [Module Lists](#module-lists)
   - [Forced Autosaves](#forced-autosaves)
-  - [Unusual Default Spawns](#unusual-default-spawns)
+  - [Notable Default Spawns](#notable-default-spawns)
 - [Related Glitches](#related-glitches)
 
 
@@ -141,9 +141,9 @@ The following table contains all 28 modules that force an Autosave.  These are m
 | Kashyyyk | Great Walkway | | Unknown Planet | Temple Main Floor |
 | Kashyyyk | Upper Shadowlands | | Star Forge | Deck 1 |
 
-### Unusual Default Spawns
+### Notable Default Spawns
 
-This is a list of all modules that have unusual default spawn locations.  While some modules' default spawns are at the usual module transition locations, these modules have more interesting default spawns that may make a [Default Spawn Warp](#default-spawn-warps) worthwhile.
+This is a list of all 37 modules that have notable default spawn locations.  While some modules' default spawns are at the usual module transition locations, these modules have more interesting default spawns that may make a [Default Spawn Warp](#default-spawn-warps) worthwhile.
 
 | **Planet** | **Module** | **Default Spawn Description** | **Coordinates** | 
 |---|---|---|---|

--- a/kotor1/Major Glitches/Spawn Warps.md
+++ b/kotor1/Major Glitches/Spawn Warps.md
@@ -25,11 +25,7 @@ There are currently two methods for warping to the default spawn location of a m
 
 ### Autosave Hotshots
 
-**Description:** Autosave Hotshots are a special method of [Hotshot](<Hotshot>) that loads an Autosave that has been saved over.  It requires a specific save setup, and thus is extremely situational.
-
-**Save Setup:**
-
-- Have the Autosave at the Destination Module
+**Description:** This method of Default Spawn Warp uses the property of [Autosave Hotshots](<Hotshot#autosave-hotshots>) that spawns the party at the default spawn location for a module.  Thus any time you use an Autosave Hotshot, you're also doing a Default Spawn Warp.  While still a specialized glitch, it is the more flexible of the two Default Spawn Warp methods.
 
 **Steps:**
 

--- a/kotor1/Major Glitches/Spawn Warps.md
+++ b/kotor1/Major Glitches/Spawn Warps.md
@@ -25,7 +25,7 @@ There are currently two methods for warping to the default spawn location of a m
 
 ### Autosave Hotshots
 
-**Description:** This method of Default Spawn Warp uses the property of [Autosave Hotshots](<Hotshot#autosave-hotshots>) that spawns the party at the default spawn location for a module.  Thus any time you use an Autosave Hotshot, you're also doing a Default Spawn Warp (unless you're performing [Transit Point Storage](#transit-point-storage).  While still a specialized glitch, Autosave Hotshots are the more flexible of the two Default Spawn Warp methods.
+**Description:** This method of Default Spawn Warp uses an [Autosave Hotshot](<Hotshot#autosave-hotshots>), which (almost) always spawns the party at the default spawn location for a module.  While still a specialized glitch, Autosave Hotshots are the more flexible of the two Default Spawn Warp methods.
 
 **Steps:**
 
@@ -50,12 +50,14 @@ There are currently two methods for warping to the default spawn location of a m
 3. Perform [the Routine](<The Routine>) to delete the Destination Module (and its transit waypoint data) from your save file.
 4. After loading your Quick Save, Transit Back to reach the Destination Module's default spawn location.
 
-*Video forthcoming*
+<div class="video-container">
+    <iframe title="YouTube video player" src="https://www.youtube.com/embed/vhXvSs_ilb4" frameborder="0"></iframe>
+</div>
 
 **Notes:**
 
 - Since [the Routine](<The Routine>) deletes most of your save file data, this method of Default Spawn Warp is best used very early in the run.
-- Also note that using [the Routine](<The Routine>) will make Save Teleporting ineffective.
+- Also note that using [the Routine](<The Routine>) will make [Save Teleporting](<../Techniques/Save Teleporting>) ineffective.
 
 ## Transit Point Storage
 

--- a/kotor1/Major Glitches/Spawn Warps.md
+++ b/kotor1/Major Glitches/Spawn Warps.md
@@ -59,7 +59,7 @@ There are currently two methods for warping to the default spawn location of a m
 
 ## Transit Point Storage
 
-Transit Point Storage is a specialized application of [Autosave Hotshots](#autosave-hotshots) that allows you to return to a fast travel waypoint in a module, even after using fast transit elsewhere.
+Transit Point Storage is a specialized application of [Autosave Hotshots](<Hotshot#autosave-hotshots>) that allows you to return to a fast travel waypoint in a module, even after using fast transit elsewhere.
 
 There are three restrictions:
 
@@ -84,7 +84,7 @@ There are three restrictions:
 </div>
 
 **Notes:**
-- Notice that steps 5-9 are a modified [Autosave Hotshot](#autosave-hotshots) using fast transit to trigger an Autosave while the Load Menu is open, rather than moving through a load zone.
+- Notice that steps 5-9 are a modified [Autosave Hotshots](<Hotshot#autosave-hotshots>) using fast transit to trigger an Autosave while the Load Menu is open, rather than moving through a load zone.
 - If no transit point has ever been set in the Destination Module, Transit Point Storage will spawn you at the default spawn location for the module.
 
 This glitch can be used to store only one transit point per module, but you can store one for every module and travel there as long as the Autosave conditions are met.  See [Forced Autosaves](#forced-autosaves) for a list of modules whose transit points can be warped to.
@@ -94,7 +94,7 @@ This glitch can be used to store only one transit point per module, but you can 
 [Default Spawn Warps](#default-spawn-warps) are used several times in Unrestricted speedruns:  
 
 - [The Routine](#the-routine) method is used to warp to Upper City South's default spawn location (near Zelka's shop).
-- [Autosave Hotshots](#autosave-hotshots) are used to warp to the following modules:
+- [Autosave Hotshots](<Hotshot#autosave-hotshots>) are used to warp to the following modules:
     - Upper City North (in all Unrestricted categories)
     - Lower City (in All Quests)
     - Dantooine Courtyard (in All Quests)
@@ -109,7 +109,7 @@ This glitch can be used to store only one transit point per module, but you can 
 
 ### Forced Autosaves
 
-The following table contains all 28 modules that force an Autosave.  These are modules that are eligible for [Autosave Hotshots](#autosave-hotshots) or [Transit Point Storage](#transit-point-storage).
+The following table contains all 28 modules that force an Autosave.  These are modules that are eligible for [Autosave Hotshots](<Hotshot#autosave-hotshots>) or [Transit Point Storage](#transit-point-storage).
 
 | **Planet** | **Module** | | **Planet** | **Module** |
 |---|---|---|---|---|

--- a/kotor1/Major Glitches/Spawn Warps.md
+++ b/kotor1/Major Glitches/Spawn Warps.md
@@ -1,4 +1,4 @@
-# Spawn Warps
+# Default Spawn Warps
 
 **Table of Contents**
 - [Description](#description)
@@ -96,12 +96,12 @@ This glitch can be used to store only one transit point per module, but you can 
 - [The Routine](#the-routine) method is used to warp to Upper City South's default spawn location (near Zelka's shop).
 - [Autosave Hotshots](<Hotshot#autosave-hotshots>) are used to warp to the following modules:
     - Upper City North (in all Unrestricted categories)
-    - Lower City (in All Quests)
-    - Dantooine Courtyard (in All Quests)
-    - West Central (in All Star Maps)
-    - Hrakert Rift (in All Star Maps)
-    - Leviathan Command Deck (in All Quests)
-    - Temple Exterior (in Any%)
+    - Lower City (in [All Quests](<../Route Guides/All Quests Unrestricted>))
+    - Dantooine Courtyard (in [All Quests](<../Route Guides/All Quests Unrestricted>))
+    - West Central (in [All Star Maps](<../Route Guides/All Star Maps>))
+    - Hrakert Rift (in [All Star Maps](<../Route Guides/All Star Maps>))
+    - Leviathan Command Deck (in [All Quests](<../Route Guides/All Quests Unrestricted>))
+    - Temple Exterior (in [Any%](<../Route Guides/Any%25Unrestricted>))
  
 [Transit Point Storage](#transit-point-storage) is used once in All Quests Unrestricted to return to the Dune Sea from Manaan.
 

--- a/kotor1/Major Glitches/The Routine.md
+++ b/kotor1/Major Glitches/The Routine.md
@@ -47,6 +47,7 @@ Once you've made these choices, make sure you have the proper in-game setup.  Yo
 ## How To
 
 Once you are in the correct module and have the correct party members in your party, use the following steps to perform the Routine:
+
 - Activate an [Anywhere Menu Glitch](<Anywhere Menu Glitch>) (AMG) with a Quick Save
 - Open the Options menu ('O' by default) 
 - Click "Exit Game".  This replaces the Alt-F4 Quit pop-up with the Exit to Main Menu Quit pop-up.
@@ -117,11 +118,11 @@ This is all done with Bastila and Jolee in our party, so that we can finish the 
 
 ## Other Uses
 
-These uses are currently not speedrun relevant.  It's also important to note that the Routine is not necessarily fully explored yet, so other benefits may exist.
+Aside from duplicating Star Maps, the other main use of the Routine in speedruns is performing a [Default Spawn Warp](<Spawn Warps#the-routine>) in Upper City South.  This saves a few seconds over running to Zelka's shop normally.
 
-* Deletes transit waypoints, resulting in the MC being warped to a module's default spawn when transiting back
-* Can be used to delete party members, which could be situationally useful
+There are not currently any other uses for the Routine, but the full implications of this glitch have not been fully explored.
 
 ## Related Glitches
 
 * [Anywhere Menu Glitch](<Anywhere Menu Glitch>)
+* [Default Spawn Warps](<Spawn Warps#default-spawn-warps>)

--- a/kotor1/Route Guides/All Quests Unrestricted.md
+++ b/kotor1/Route Guides/All Quests Unrestricted.md
@@ -299,7 +299,7 @@ Other planet route notes:
 
 **2. Taris 2**
 - Inventory Dupe from Hideout
-- Autosave Hotshot to Lower City
+- Default Spawn Warp to Lower City
 - Bounty for Selven
 - Eliminate Infected Outcasts
 - Recruit Mission and Zaalbar
@@ -703,8 +703,8 @@ SHOPPING: Zelka Forn
   - Load Slot 4 and exit the apartments to get an Autosave in Upper City North
   - QL and activate [AMG](<../Major Glitches/Anywhere Menu Glitch>) on the load
   - [Neo Hotshot](<../Major Glitches/Hotshot#neo-hotshots>) to South Apartments using Slot 3
-  - [Transit Point Storage](<../Major Glitches/Hotshot#transit-point-storage>) to warp to Upper City North's default spawn
-    - Activate [AMG](<../Major Glitches/Anywhere Menu Glitch>) on the Neo Hotshot load, then click to close the menu
+  - [Default Spawn Warp](<../Major Glitches/Spawn Warps#autosave-hotshots>) to Upper City North via [Transit Point Storage](<../Major Glitches/Spawn Warps#transit-point-storage>)
+    - Activate [AMG](<../Major Glitches/Anywhere Menu Glitch>) on the [Neo Hotshot](<../Major Glitches/Hotshot#neo-hotshots>) load, then click to close the menu
     - Open the Map and click "Transit Back" to replace the pop-up
     - Swap to the Options Menu, highlight "Load Game" and "OK", then press enter
     - After the load, load the Autosave to warp to Upper City North
@@ -828,7 +828,7 @@ SHOPPING: Zelka Forn
 - [Full Inventory Dupe](<../Techniques/Item Duplication#via-anywhere-menu-glitch>) via the [AMG](<../Major Glitches/Anywhere Menu Glitch>) method
 - Activate [AMG](<../Major Glitches/Anywhere Menu Glitch>) on the load leaving the Hideout and immediately [Map CS Skip](<../Techniques/Map Cutscene Skips>) to open the map
   - This can be tricky because the [AMG](<../Major Glitches/Anywhere Menu Glitch>) pulls your mouse away from where it needs to be for the [Map CS Skip](<../Techniques/Map Cutscene Skips>)
-- Use the pop-up to [Transit Point Storage](<../Major Glitches/Hotshot#transit-point-storage>) to the Lower City
+- [Default Spawn Warp](<../Major Glitches/Spawn Warps#autosave-hotshots>) to Lower City via [Transit Point Storage](<../Major Glitches/Spawn Warps#transit-point-storage>) using the pop-up
 - [Hard Buffer](<../Techniques/Save Buffering#hard-buffers>) to skip extortion CS in front of apartments
 - *Party: Add Carth*
   - This duplicates your inventory once
@@ -1122,8 +1122,7 @@ to hit Sherruk
   - ***Begins "Juhani"***
 - [Neo Hotshot](<../Major Glitches/Hotshot#neo-hotshots>) to Ruins using Slot 4
 - Exit the Ruins and [AMG](<../Major Glitches/Anywhere Menu Glitch>) on the load
-- [Autosave Hotshot](<../Major Glitches/Hotshot#autosave-hotshots>) to Courtyard by re-entering the Ruins
-  - This puts you at the default spawn in the Courtyard, right next to Elise
+- [Default Spawn Warp](<../Major Glitches/Spawn Warps#autosave-hotshots>) to Courtyard via [Autosave Hotshot](<../Major Glitches/Hotshot#autosave-hotshots>) by re-entering the Ruins
 - Talk to Elise
   - ***Finishes "Missing Companion"***
 - Talk to Jon
@@ -1386,7 +1385,7 @@ SHOPPING: Junix Nard
 - Loot talking rubble in swoop crash area to trigger Gamorrean ambush: 4,1
   - ***Finishes "A Desert Ambush"***
 - RtEH and Transit Back to create a transit point
-  - We will use this for [Transit Point Storage](<../Major Glitches/Hotshot#transit-point-storage>) later
+  - We will use this for [Transit Point Storage](<../Major Glitches/Spawn Warps#transit-point-storage>) later
 - [Save Teleport](<../Techniques/Save Teleporting>) to skip trigger and enter the Eastern Dune Sea
   - *Suggested Memory Reset #3*
 - [Soft Buffer](<../Techniques/Save Buffering#soft-buffers>) from entrance to Komad
@@ -1519,10 +1518,14 @@ SHOPPING: Selkath Merchant
 - When the CS ends, use the shuttle to reach the Manaan Sith Base
 - **Hard Save in New Slot (Slot 9)**
   - Do *NOT* use the keyboard for this or you'll break the transit pop-up!
-- After the Hard Save, use the pop-up to [Fast Lane](<../Major Glitches/Fast Lane>) to RtEH
-- QS, then load the Anchorhead save (Slot 5)
-- Talk to the Gate Guard to get the Dune Sea Autosave
-- QL and activate [AMG](<../Major Glitches/Anywhere Menu Glitch>) on the load to perform [Transit Point Storage](<../Major Glitches/Hotshot#transit-point-storage>)
+- Perform [Transit Point Storage](<../Major Glitches/Spawn Warps#transit-point-storage>) to reach the Dune Sea:
+  - After the Hard Save, use the pop-up to [Fast Lane](<../Major Glitches/Fast Lane>) to RtEH
+  - QS, then load the Anchorhead save (Slot 5)
+  - Talk to the Gate Guard to get the Dune Sea Autosave
+  - QL and activate [AMG](<../Major Glitches/Anywhere Menu Glitch>) on the load
+  - Open the map and click Transit Back to replace the quit game pop-up with the fast travel pop-up
+  - Switch to the Options menu, ensure 'Load Game' and 'OK' are highlighted, and press Enter
+  - After the load, load the Autosave to finish the [Transit Point Storage](<../Major Glitches/Spawn Warps#transit-point-storage>)
 
 ## Tatooine 2
 
@@ -1692,7 +1695,7 @@ SHOPPING: Selkath Merchant
   - Activate [AMG](<../Major Glitches/Anywhere Menu Glitch>) on the load into Command Deck
 
 **Command Deck:**
-- Use the elevator controls to [Autosave Hotshot](<../Major Glitches/Hotshot#autosave-hotshots>) to the Command Deck
+- [Default Spawn Warp](<../Major Glitches/Spawn Warps#autosave-hotshots>) to Command Deck via [Autosave Hotshot](<../Major Glitches/Hotshot#autosave-hotshots>) by using the elevator controls
   - Instead of going through a load zone, first position MC so the controls are targeted
   - Once on the load game menu, unpause and use Default Action to select 1 go to Prison Block
 - *Force: Cast Master Speed*

--- a/kotor1/Route Guides/All Star Maps.md
+++ b/kotor1/Route Guides/All Star Maps.md
@@ -71,7 +71,7 @@ A brief outline of the route for the ASM run, including planet order and major s
 * Reach West Central
 * [Coordinate Warp](<../Major Glitches/Coordinate Warps#docking-bay-to-upper-shadowlands>) Bastila to Upper Shadowlands
 * Reach Lower Shadowlands
-* [Autosave Hotshot](<../Major Glitches/Hotshot#autosave-hotshots>) to West Central
+* [Default Spawn Warp](<../Major Glitches/Spawn Warps#default-spawn-warps>) to West Central
 * Reach East Central
 
 *5. Map Collection*
@@ -84,7 +84,7 @@ A brief outline of the route for the ASM run, including planet order and major s
 * [Coordinate Warp](<../Major Glitches/Coordinate Warps#bandon-cutscene-to-sea-floor>) Jolee from a STUNT module to the Sea Floor to skip the disguise
 * [Coordinate Warp](<../Major Glitches/Coordinate Warps#kolto-control-to-anchorhead>) Jolee to Anchorhead to reach the Dune Sea
 * [Coordinate Warp](<../Major Glitches/Coordinate Warps#anchorhead-to-kolto-control>) Jolee to Kolto Control to reach Hrakert Rift
-* [Autosave Hotshot](<../Major Glitches/Hotshot#autosave-hotshots>) to Hrakert Rift to get the Manaan Star Map
+* [Default Spawn Warp](<../Major Glitches/Spawn Warps#default-spawn-warps>) to Hrakert Rift to get the Manaan Star Map
 * [Coordinate Warp](<../Major Glitches/Coordinate Warps#upper-shadowlands-to-dune-sea>) Jolee to Dune Sea via Upper Shadowlands to reach Eastern Dune Sea
 * Krayt Dragon Skip to get the Tatooine Star Map
 
@@ -104,7 +104,7 @@ A brief outline of the route for the ASM run, including planet order and major s
 * [Coordinate Warp](<../Major Glitches/Coordinate Warps#lower-shadowlands-to-command-center>) Bastila to Viewing Platform
 * Kill Darth Malak with Thermal Detonators and an [AMG](<../Major Glitches/Anywhere Menu Glitch>)
 
-This route used to obtain either Sith Armor or the Sand People Outfit so a [Fast Lane](<../Major Glitches/Fast Lane>) could be used to remove the Envirosuit.  These can now be skipped thanks to the [STUNT module Coordinate Warp](<../Major Glitches/Coordinate Warps#bandon-cutscene-to-sea-floor>) to Sea Floor and the [Autosave Hotshot](<../Major Glitches/Hotshot#autosave-hotshots>) to Hrakert Rift.  Those two warps, along with the [Coordinate Warp to the Envirosuit](<../Major Glitches/Coordinate Warps#tomb-of-naga-sadow-to-hrakert-station>), also enable Plot Armor Skip, since these are the only points that would have a high risk of death (other than the Taris Sith Base).
+This route used to obtain either Sith Armor or the Sand People Outfit so a [Fast Lane](<../Major Glitches/Fast Lane>) could be used to remove the Envirosuit.  These can now be skipped thanks to the [STUNT module Coordinate Warp](<../Major Glitches/Coordinate Warps#bandon-cutscene-to-sea-floor>) to Sea Floor and the [Default Spawn Warp](<../Major Glitches/Spawn Warps#default-spawn-warps>) to Hrakert Rift.  Those two warps, along with the [Coordinate Warp to the Envirosuit](<../Major Glitches/Coordinate Warps#tomb-of-naga-sadow-to-hrakert-station>), also enable Plot Armor Skip, since these are the only points that would have a high risk of death (other than the Taris Sith Base).
 
 ## Character Build
 
@@ -277,7 +277,7 @@ SHOPPING: Larrim
 
 ### Upper City South
 
-- ***Optional Strat: Default Spawn Warp***
+- ***Optional Strat: [Default Spawn Warp](<../Major Glitches/Spawn Warps#the-routine>)***
   - *This strat uses [The Routine](<../Major Glitches/The Routine>) to warp to the default spawn in Upper City South, just outside Zelka's clinic.  It's a very complicated glitch that saves only 2-3 seconds, so it's only recommended for top runners.*
   - *To perform this strat:*
     - Return to the Hideout
@@ -307,7 +307,7 @@ SHOPPING: Larrim
 ### Upper City North
 
 - Activate [AMG](<../Major Glitches/Anywhere Menu Glitch>) on the Upper City North load screen
-- [Autosave Hotshot](<../Major Glitches/Hotshot#autosave-hotshots>) to warp to elevator:
+- [Default Spawn Warp](<../Major Glitches/Spawn Warps#the-routine>) via [Autosave Hotshot](<../Major Glitches/Hotshot#autosave-hotshots>) to reach Lower City elevator:
   - With quit dialog up, unpause and open the door to Upper City South behind you
   - Open the Options menu, then press enter with Load Game and Cancel selected
   - Unpause and navigate blindly through the door to Upper City South
@@ -529,9 +529,8 @@ SHOPPING: Larrim
 
 - *Stims: Adrenal Alacrity on MC*
 - Open two doors, then [Hard Buffer](<../Techniques/Save Buffering#hard-buffers>) to skip the Sith/Republic convo
-  - It is important not to QS again after this buffer until you reload the save
-- Enter West Central for the Autosave
-- Immediately QL to return to the Manaan Docking Bay
+  - It is important not to QS again until after you reach West Central
+- Enter West Central for the Autosave and immediately QL to return to the Manaan Docking Bay
 - Activate Solo Mode and [AMG](<../Major Glitches/Anywhere Menu Glitch>) via QS
 - Swap to Bastila and run to the wall opposite the hallway to the Ebon Hawk
 - [Neo Hotshot](<../Major Glitches/Hotshot#neo-hotshots>) to [Coordinate Warp](<../Major Glitches/Coordinate Warps#docking-bay-to-upper-shadowlands>) Bastila to Upper Shadowlands using Slot 2
@@ -549,7 +548,7 @@ SHOPPING: Larrim
   - *[Save Teleports](<../Techniques/Save Teleporting>) are now the most effective form of movement.*
 - Once in the Lower Shadowlands, **Hard Save in Slot 5**
   - Activate [AMG](<../Major Glitches/Anywhere Menu Glitch>) on this Hard Save (or via QS)
-- [Autosave Hotshot](<../Major Glitches/Hotshot#autosave-hotshots>) using the Upper Shadowlands load zone
+- [Default Spawn Warp](<../Major Glitches/Spawn Warps#autosave-hotshots>) to West Central via [Autosave Hotshot](<../Major Glitches/Hotshot#autosave-hotshots>) using the Upper Shadowlands load zone
 - Swap to MC and talk to Port Authority: 1,1
 - Swap to Jolee and [Save Teleport](<../Techniques/Save Teleporting>) to enter East Central
 
@@ -622,7 +621,7 @@ SHOPPING: Larrim
 - [Neo Hotshot](<../Major Glitches/Hotshot#neo-hotshots>) to [Coordinate Warp](<../Major Glitches/Coordinate Warps#anchorhead-to-kolto-control>) Jolee to Kolto Control using Slot 1
 - Activate the airlock to get the Hrakert Rift Autosave, then immediately QL
 - Swap to MC and activate [AMG](<../Major Glitches/Anywhere Menu Glitch>) via QS
-- [Autosave Hotshot](<../Major Glitches/Hotshot#autosave-hotshots>) using the gate guard
+- [Default Spawn Warp](<../Major Glitches/Spawn Warps#autosave-hotshots>) to Hrakert Rift via [Autosave Hotshot](<../Major Glitches/Hotshot#autosave-hotshots>) using the gate guard
   - Face the gate guard, set up the Hotshot, then use default action to talk to him and reach the Dune Sea
   - Load the Autosave after that
 - After loading in Hrakert Rift, activate Solo Mode

--- a/kotor1/index.md
+++ b/kotor1/index.md
@@ -37,13 +37,12 @@ Glitch guides are split into two types:
 |---|---|---|---|---|---|---|
 | [Anywhere Menu Glitch](./Major%20Glitches/Anywhere%20Menu%20Glitch) | [Coordinate Warps](./Major%20Glitches/Coordinate%20Warps) | [Displaced Load Zone](./Major%20Glitches/Displaced%20Load%20Zone) | | [Combat Talking](./Techniques/Combat%20Talking) | [Conversation Overlay](./Techniques/Conversation%20Overlay) | [Conversation Queue](./Techniques/Conversation%20Queue) |
 | [Door Clipping](./Major%20Glitches/Door%20Clipping) | [Fake Level Up](./Major%20Glitches/Fake%20Level%20Up) | [Fast Lane](./Major%20Glitches/Fast%20Lane) | | [Damage Stacking](./Techniques/Damage%20Stacking) | [Force Skips](./Techniques/Force%20Skips) | [Gather Party Warp](./Techniques/GP%20Warp) |
-| [Hotshot](./Major%20Glitches/Hotshot) | [The Routine](./Major%20Glitches/The%20Routine) | | | [Item Duplication](./Techniques/Item%20Duplication) | [Jedi Mine Trick](./Techniques/Jedi%20Mine%20Trick) | [Map Cutscene Skips](./Techniques/Map%20Cutscene%20Skips) |
+| [Hotshot](./Major%20Glitches/Hotshot) | [The Routine](./Major%20Glitches/The%20Routine) | [Spawn Warps](./Major%20Glitches/Spawn%20Warps) | | [Item Duplication](./Techniques/Item%20Duplication) | [Jedi Mine Trick](./Techniques/Jedi%20Mine%20Trick) | [Map Cutscene Skips](./Techniques/Map%20Cutscene%20Skips) |
 | | | | | [Save Buffering](./Techniques/Save%20Buffering) | [Save Teleporting](./Techniques/Save%20Teleporting) | [Wired Targeting](./Techniques/Wired%20Targeting) |
 
 ## Miscellaneous Info
 
 - [Enemy Spawn Triggers](./Miscellaneous/Enemy%20Spawn%20Triggers)
-
 
 ## Useful Links
 


### PR DESCRIPTION
Create a Spawn Warps guide containing:

- Default Spawn Warps (both Autosave Hotshot and Routine versions)
- Transit Point Storage (moved from Hotshot guide)
- Module Lists for Forced Autosaves and Notable Default Spawns

Update other Major Glitch guides and Route Guides to update hyperlinks and reference the new guide where appropriate.