### PR TITLE
Refresh Discord Invites

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -58,7 +58,7 @@
                 <img class="svg" src="{{ "/assets/images/SRC.svg" | relative_url }}" title="Leaderboards" alt="Kotor Series Leaderboards">
             </a>
             {% endif %}
-            <a href="http://discord.gg/Q2uPRVu">
+            <a href="https://discord.gg/6WpNfRZ">
                 <img class="svg" src="{{ "/assets/images/discord.svg" | relative_url }}" title="Discord" alt="Join our Discord Server!">
             </a>
         </div>

--- a/index.html
+++ b/index.html
@@ -17,6 +17,6 @@ layout: default
     </tbody>
 </table>
 
-<p>These guides are community owned and maintained; if you’d like to contribute to the project, <a href="http://discord.gg/Q2uPRVu">join our discord</a> and check out our <a href="https://github.com/kotor-speedruns/kotor-speedruns.github.io">GitHub repo</a>!</p>
+<p>These guides are community owned and maintained; if you’d like to contribute to the project, <a href="https://discord.gg/6WpNfRZ">join our discord</a> and check out our <a href="https://github.com/kotor-speedruns/kotor-speedruns.github.io">GitHub repo</a>!</p>
 
 <p><em>Site edited by <a href="https://www.speedrun.com/users/Lane">Lane</a> and <a href="https://www.speedrun.com/users/indykenobi">indykenobi</a></em></p>

--- a/kotor1/index.md
+++ b/kotor1/index.md
@@ -11,7 +11,7 @@ Welcome to the KotOR I Speedrunning Guides! Here you'll find a wealth of informa
 ## New to KotOR Speedrunning?
 
 If you're just beginning your KotOR speedrun journey, the following links will help you get started:
-- The [KotOR Speedrunning Discord](http://discord.gg/Q2uPRVu) is the place for all speedy KotOR discussion! We're a helpful community and always excited to see new runners.
+- The [KotOR Speedrunning Discord](https://discord.gg/6WpNfRZ) is the place for all speedy KotOR discussion! We're a helpful community and always excited to see new runners.
 - Our [Getting Started with KotOR Speedrunning](Getting%20Started) guide can help with basic questions, as well as the right settings for your game to streamline the speedrunning process.
 - If you're having trouble running KotOR on Windows 10, this [Windows 10 Guide](./Miscellaneous/Windows%2010) may be helpful as well.
 

--- a/kotor2/index.md
+++ b/kotor2/index.md
@@ -11,7 +11,7 @@ Welcome to the KotOR II Speedrunning Guides! Here you'll find a wealth of inform
 ## New to KotOR Speedrunning?
 
 If you're just beginning your KotOR speedrun journey, the following links will help you get started:
-- The [KotOR Speedrunning Discord](http://discord.gg/Q2uPRVu) is the place for all speedy KotOR discussion! We're a helpful community and always excited to see new runners.
+- The [KotOR Speedrunning Discord](https://discord.gg/6WpNfRZ) is the place for all speedy KotOR discussion! We're a helpful community and always excited to see new runners.
 - Our [Getting Started with KotOR Speedrunning](Getting%20Started) guide can help with basic questions, as well as the right settings for your game to streamline the speedrunning process.
 
 ## Route Guides


### PR DESCRIPTION
Looks like discord updated their invite scheme to use https, so a lot of the older http invite links are becoming stale for user-agents that enforce https.
I'm refreshing our discord invite in a few places I can think of, though keep this in mind if someone has trouble joining
