### PR TITLE
Refresh Discord Invites

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Hit `Ctrl+C` in the terminal to stop the website.
 - [Guide Website](https://kotor-speedruns.github.io/)
 - [GitHub Markdown Docs](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)
 - [Markdown Table of Contents Generator](https://luciopaiva.com/markdown-toc/)
-- [KotOR Speedrunning Discord](http://discord.gg/Q2uPRVu)
+- [KotOR Speedrunning Discord](https://discord.gg/6WpNfRZ)
 - [Leaderboards](https://www.speedrun.com/kotor1)
 
 ## Contact

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -58,7 +58,7 @@
                 <img class="svg" src="{{ "/assets/images/SRC.svg" | relative_url }}" title="Leaderboards" alt="Kotor Series Leaderboards">
             </a>
             {% endif %}
-            <a href="http://discord.gg/Q2uPRVu">
+            <a href="https://discord.gg/6WpNfRZ">
                 <img class="svg" src="{{ "/assets/images/discord.svg" | relative_url }}" title="Discord" alt="Join our Discord Server!">
             </a>
         </div>
@@ -68,7 +68,7 @@
     </div>
     <!-- <div class="footer">
         <ul>
-            <li><a href="http://discord.gg/Q2uPRVu">KotOR Discord</a></li>
+            <li><a href="https://discord.gg/6WpNfRZ">KotOR Discord</a></li>
             <li><a href="https://www.speedrun.com/">KotOR Speedrun.com</a></li>
             <li><a href="/about/">About</a></li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -17,6 +17,6 @@ layout: default
     </tbody>
 </table>
 
-<p>These guides are community owned and maintained; if you’d like to contribute to the project, <a href="http://discord.gg/Q2uPRVu">join our discord</a> and check out our <a href="https://github.com/kotor-speedruns/kotor-speedruns.github.io">GitHub repo</a>!</p>
+<p>These guides are community owned and maintained; if you’d like to contribute to the project, <a href="https://discord.gg/6WpNfRZ">join our discord</a> and check out our <a href="https://github.com/kotor-speedruns/kotor-speedruns.github.io">GitHub repo</a>!</p>
 
 <p><em>Site edited by <a href="https://www.speedrun.com/users/Lane">Lane</a> and <a href="https://www.speedrun.com/users/indykenobi">indykenobi</a></em></p>

--- a/kotor1/Getting Started.md
+++ b/kotor1/Getting Started.md
@@ -17,7 +17,7 @@
 
 If you're just wanting to get started speedrunning KotOR, this is the place to start!  This guide covers the basics of KotOR speedruns, from how to actually get KotOR running and the appropriate settings, to how to use these guides to answer the questions you have.
 
-If there's something that isn't covered here or in a different guide, feel free to join the [KotOR Speedrunning Discord](http://discord.gg/Q2uPRVu).  The community is pretty friendly and always willing to help!
+If there's something that isn't covered here or in a different guide, feel free to join the [KotOR Speedrunning Discord](https://discord.gg/6WpNfRZ).  The community is pretty friendly and always willing to help!
 
 ## KotOR Speedrun Overview
 

--- a/kotor1/Miscellaneous/KotOR Bingo.md
+++ b/kotor1/Miscellaneous/KotOR Bingo.md
@@ -1079,4 +1079,4 @@ For the purposes of these tasks, *Permanent* means either base points from Attri
 
 ## More Resources
 
-The best resource for KotOR Bingo would be to visit the [KotOR Speedrunning Discord](http://discord.gg/Q2uPRVu).  The variety-runs channel is the place to ask your bingo related questions!
+The best resource for KotOR Bingo would be to visit the [KotOR Speedrunning Discord](https://discord.gg/6WpNfRZ).  The variety-runs channel is the place to ask your bingo related questions!

--- a/kotor1/Miscellaneous/Pazaak.md
+++ b/kotor1/Miscellaneous/Pazaak.md
@@ -177,4 +177,4 @@ I've often found that it helps to view my hand immediately, and briefly recite t
 
 ### Ask for Help
 
-The best way to get good at Pazaak is to talk to others who have played a lot of this game, and sample their strategies. You can get in contact with most of the people from this site on our [KotOR Speedrunning Discord](http://discord.gg/Q2uPRVu).
+The best way to get good at Pazaak is to talk to others who have played a lot of this game, and sample their strategies. You can get in contact with most of the people from this site on our [KotOR Speedrunning Discord](https://discord.gg/6WpNfRZ).

--- a/kotor1/Miscellaneous/Swoop Racing.md
+++ b/kotor1/Miscellaneous/Swoop Racing.md
@@ -25,6 +25,8 @@ I’m making this mainly to expand the number of runners in the swoop racing sec
 - The [original guide](https://drive.google.com/file/d/1RYEDbI1_cIP_LSyi_jOROBydYxQQaVtK/view?usp=sharing) was based in a pdf made by [TheLadiesLoveMe](https://www.speedrun.com/users/TheLadiesLoveMe). I decided to move it into SRC format both to make our guides more cohesive and for archiving purposes. *-Lane*
 - The guide is now transferred to the GitHub repo after SRC broke their guides, and I've reformatted it for readability. *-indy*
 
+Finally, if you have additional questions, you can check out the [KotOR Speedrunning Discord](https://discord.gg/6WpNfRZ). There's a bunch of friendly folks there willing to answer questions!
+
 ## Setup
 
 While most settings are irrelevant to swoops there are a few things you will need to tweak:

--- a/kotor1/Route Guides/All Quests Glitchless.md
+++ b/kotor1/Route Guides/All Quests Glitchless.md
@@ -8,6 +8,8 @@ This route completes all 100 main and side quests in the game without the benefi
 
 Dark side or light side quest conclusions are chosen based on overall speed for the route.  This guide will cover the character creation and leveling choices, as well as reasoning for each quest's chosen completion and a detailed route.
 
+You can also join the [KotOR Speedrunning Discord](https://discord.gg/6WpNfRZ) and ask questions if you have them!
+
 **Table of Contents**
 - [Category Rules](#category-rules)
   - [All Quests Category](#all-quests-category)

--- a/kotor1/Route Guides/All Quests NMG.md
+++ b/kotor1/Route Guides/All Quests NMG.md
@@ -8,7 +8,7 @@ This route completes all 100 main and side quests in the game without the use of
 
 Dark side or light side quest conclusions are chosen based on overall speed for the route.  This guide will cover the character creation and leveling choices, as well as reasoning for each quest's chosen completion and a detailed route.
 
-If you need assistance with the glitches used in the game, I recommend the Techniques section of the [Glitch Guides](https://kotor-speedruns.github.io/kotor1/#glitch-guides).  You can either review those guides ahead of time, or use the hyperlinks in the guide below to consult the more detailed material when necessary.  You can also join the [KotOR Speedrunning Discord](http://discord.gg/Q2uPRVu) and ask questions if you have them!
+If you need assistance with the glitches used in the game, I recommend the Techniques section of the [Glitch Guides](https://kotor-speedruns.github.io/kotor1/#glitch-guides).  You can either review those guides ahead of time, or use the hyperlinks in the guide below to consult the more detailed material when necessary.  You can also join the [KotOR Speedrunning Discord](https://discord.gg/6WpNfRZ) and ask questions if you have them!
 
 **Table of Contents:**
 - [Category Rules](#category-rules)

--- a/kotor1/Route Guides/All Quests Unrestricted.md
+++ b/kotor1/Route Guides/All Quests Unrestricted.md
@@ -10,7 +10,7 @@ This route completes all 100 main and side quests in the game with no restrictio
 
 Dark side or light side quest conclusions are chosen based on overall speed for the route. This guide will cover the character creation and leveling choices, as well as reasoning for each quest’s chosen completion and a detailed route.
 
-If you need assistance with the glitches used in the game, I recommend the [Glitch Guides](https://kotor-speedruns.github.io/kotor1/#glitch-guides).  You can either review those guides ahead of time, or use the hyperlinks in the guide below to consult the more detailed material when necessary.  You can also join the [KotOR Speedrunning Discord](http://discord.gg/Q2uPRVu) and ask questions if you have them!
+If you need assistance with the glitches used in the game, I recommend the [Glitch Guides](https://kotor-speedruns.github.io/kotor1/#glitch-guides).  You can either review those guides ahead of time, or use the hyperlinks in the guide below to consult the more detailed material when necessary.  You can also join the [KotOR Speedrunning Discord](https://discord.gg/6WpNfRZ) and ask questions if you have them!
 
 **Table of Contents:**
 - [Category Rules](#category-rules)

--- a/kotor1/Route Guides/All Star Maps.md
+++ b/kotor1/Route Guides/All Star Maps.md
@@ -6,7 +6,7 @@
 
 This route defeats Malak on the Star Forge as fast as possible while obtaining all five individual Star Maps.  Timing begins upon clicking "PLAY" after character creation and ends when the screen cuts to black at the start of the Malak Death cutscene. A load-removal tool and auto-splitter is available for LiveSplit thanks to [Lane](https://www.speedrun.com/users/Lane), [glasnonck](https://www.speedrun.com/users/glasnonck) and [XeroHR](https://www.speedrun.com/users/XeroHR). Times are sorted based on load-removed times, since load times vary significantly in this game, and saving is frequent. This guide will cover the character build and detailed route for the run.
 
-Finally, if you have additional questions, you can check out the [KotOR Speedrunning Discord](http://discord.gg/Q2uPRVu). There's a bunch of friendly folks there willing to answer questions!
+Finally, if you have additional questions, you can check out the [KotOR Speedrunning Discord](https://discord.gg/6WpNfRZ). There's a bunch of friendly folks there willing to answer questions!
 
 
 **Table of Contents**

--- a/kotor1/Route Guides/Any% Glitchless.md
+++ b/kotor1/Route Guides/Any% Glitchless.md
@@ -8,7 +8,7 @@ redirect_from:
 
 This route defeats Malak on the Star Forge as fast as possible without the use of glitches.  Timing begins upon clicking "PLAY" after character creation and ends when the screen cuts to black at the start of the Malak Death cutscene. A load-removal tool and auto-splitter is available for LiveSplit thanks to [Lane](https://www.speedrun.com/users/Lane), [glasnonck](https://www.speedrun.com/users/glasnonck) and [XeroHR](https://www.speedrun.com/users/XeroHR). Times are sorted based on load-removed times, since load times vary significantly in this game, and load screens are frequent. This guide will cover the character build for the run, as well as a detailed route.
 
-If you have additional questions, you can check out the [KotOR Speedrunning Discord](http://discord.gg/Q2uPRVu) which is linked on the game's sidebar on speedrun.com.  There's a bunch of friendly folks there willing to answer questions!
+If you have additional questions, you can check out the [KotOR Speedrunning Discord](https://discord.gg/6WpNfRZ) which is linked on the game's sidebar on speedrun.com.  There's a bunch of friendly folks there willing to answer questions!
 
 **Table of Contents:**
 - [Glitchless Ruleset](#glitchless-ruleset)

--- a/kotor1/Route Guides/Any% NMG.md
+++ b/kotor1/Route Guides/Any% NMG.md
@@ -8,7 +8,7 @@ redirect_from:
 
 This route defeats Malak on the Star Forge as fast as possible without major glitches.  Timing begins upon clicking "PLAY" after character creation and ends when the screen cuts to black at the start of the Malak Death cutscene. A load-removal tool and auto-splitter is available for LiveSplit thanks to [Lane](https://www.speedrun.com/users/Lane), [glasnonck](https://www.speedrun.com/users/glasnonck) and [XeroHR](https://www.speedrun.com/users/XeroHR). Times are sorted based on load-removed times, since load times vary significantly in this game, and saving is frequent. This guide will cover the character build for the run, as well as a detailed route.
 
-If you have additional questions, you can check out the [KotOR Speedrunning Discord](http://discord.gg/Q2uPRVu) which is linked on the game's sidebar on speedrun.com.  There's a bunch of friendly folks there willing to answer questions!
+If you have additional questions, you can check out the [KotOR Speedrunning Discord](https://discord.gg/6WpNfRZ) which is linked on the game's sidebar on speedrun.com.  There's a bunch of friendly folks there willing to answer questions!
 
 **Table of Contents:**
 - [NMG Ruleset](#nmg-ruleset)

--- a/kotor1/Route Guides/Any% Unrestricted.md
+++ b/kotor1/Route Guides/Any% Unrestricted.md
@@ -10,7 +10,7 @@ redirect_from:
 
 This route defeats Malak on the Star Forge as fast as possible; Timing begins upon clicking "PLAY" after character creation and ends when the screen cuts to black at the start of the Malak Death cutscene. A load-removal tool and auto-splitter is available for LiveSplit thanks to [Lane](https://www.speedrun.com/users/Lane), [glasnonck](https://www.speedrun.com/users/glasnonck) and [XeroHR](https://www.speedrun.com/users/XeroHR). Times are sorted based on load-removed times, since load times vary significantly in this game, and saving is frequent. This guide will cover the character build and detailed route for the run.
 
-Finally, if you have additional questions, you can check out the [KotOR Speedrunning Discord](http://discord.gg/Q2uPRVu). There's a bunch of friendly folks there willing to answer questions!
+Finally, if you have additional questions, you can check out the [KotOR Speedrunning Discord](https://discord.gg/6WpNfRZ). There's a bunch of friendly folks there willing to answer questions!
 
 **Table of Contents**
 - [Unrestricted Ruleset](#unrestricted-ruleset)

--- a/kotor1/Video Tutorials/Any% NMG.md
+++ b/kotor1/Video Tutorials/Any% NMG.md
@@ -21,7 +21,7 @@ There are two video tutorials for Any% No Major Glitches:
 
 Both tutorials correspond to v4.3 of the [written guide](<./Route Guides/Any%25 NMG>), though there are significant differences in their approaches.  Both tutorials fully explain the glitches necessary to complete the run, so no prior knowledge is necessary before watching these tutorials (although knowing how to play KotOR is probably helpful).
 
-If you have further questions, ask in the [KotOR Speedrunning Discord](http://discord.gg/Q2uPRVu)!
+If you have further questions, ask in the [KotOR Speedrunning Discord](https://discord.gg/6WpNfRZ)!
 
 ## Overview Tutorial
 

--- a/kotor1/Video Tutorials/Old Video Tutorials.md
+++ b/kotor1/Video Tutorials/Old Video Tutorials.md
@@ -304,7 +304,7 @@ This is a video tutorial for the All Quests Unrestricted category of KotOR.  Thi
 
 The video tutorial is split into 15 episodes, and exists in its entirety in this [YouTube playlist](https://www.youtube.com/watch?v=lOkItSf_X-I&list=PLOUtDgJwg14F-oNebziBKpmzEmmijqAQT). The tutorial assumes knowledge of the common glitches used in the Unrestricted ruleset, including [buffer glitches](<../Techniques/Save Buffering>), [Hotshots](<../Major Glitches/Hotshots>), [AMG](<../Major Glitches/Anywhere Menu Glitch>), [GP Warps](<../Techniques/GP Warp>), and others.
 
-If you have questions, ask in the [KotOR Speedrunning Discord](http://discord.gg/Q2uPRVu)!
+If you have questions, ask in the [KotOR Speedrunning Discord](https://discord.gg/6WpNfRZ)!
 
 ### v1.2 
 

--- a/kotor1/index.md
+++ b/kotor1/index.md
@@ -11,7 +11,7 @@ Welcome to the KotOR I Speedrunning Guides! Here you'll find a wealth of informa
 ## New to KotOR Speedrunning?
 
 If you're just beginning your KotOR speedrun journey, the following links will help you get started:
-- The [KotOR Speedrunning Discord](http://discord.gg/Q2uPRVu) is the place for all speedy KotOR discussion! We're a helpful community and always excited to see new runners.
+- The [KotOR Speedrunning Discord](https://discord.gg/6WpNfRZ) is the place for all speedy KotOR discussion! We're a helpful community and always excited to see new runners.
 - Our [Getting Started with KotOR Speedrunning](Getting%20Started) guide can help with basic questions, as well as the right settings for your game to streamline the speedrunning process.
 - If you're having trouble running KotOR on Windows 10, this [Windows 10 Guide](./Miscellaneous/Windows%2010) may be helpful as well.
 
@@ -50,7 +50,7 @@ Glitch guides are split into two types, with an extra guide for things that are 
 Here's some useful external links that can be helpful for KotOR I speedrunning.
 
 ### General Links
-- [KotOR Speedrunning Discord](http://discord.gg/Q2uPRVu)
+- [KotOR Speedrunning Discord](https://discord.gg/6WpNfRZ)
 - [Leaderboards](https://www.speedrun.com/kotor1)
 - [KotOR 1 StrategyWiki](https://strategywiki.org/wiki/Star_Wars:_Knights_of_the_Old_Republic)
 - [Walkmesh Visualizer](https://github.com/glasnonck/WalkmeshVisualizer) by [glasnonck](https://www.speedrun.com/users/glasnonck)
@@ -91,4 +91,4 @@ Here's some useful external links that can be helpful for KotOR I speedrunning.
 
 This guide repository is community owned and maintained.  If you would like to contribute a guide, make a correction to an existing guide, or help edit this repository, feel free to make a pull request.  Each guide has a convenient <img src="/assets/images/github.svg" alt="GitHub Logo" width="16" height="16"> link at the top that leads to the source file for ease of access.
 
-Contact [Lane](https://www.speedrun.com/users/Lane), [indykenobi](https://www.speedrun.com/users/indykenobi), or another moderator on the [KotOR Speedrunning Discord](http://discord.gg/Q2uPRVu) if you have any questions.
+Contact [Lane](https://www.speedrun.com/users/Lane), [indykenobi](https://www.speedrun.com/users/indykenobi), or another moderator on the [KotOR Speedrunning Discord](https://discord.gg/6WpNfRZ) if you have any questions.

--- a/kotor2/Getting Started.md
+++ b/kotor2/Getting Started.md
@@ -12,7 +12,7 @@
 
 If you're just wanting to get started speedrunning KotOR, this is the place to start!  This guide covers the basics of KotOR speedruns, from how to actually get KotOR running and the appropriate settings, to how to use these guides to answer the questions you have.
 
-If there's something that isn't covered here or in a different guide, feel free to join the [KotOR Speedrunning Discord](http://discord.gg/Q2uPRVu).  The community is pretty friendly and always willing to help!
+If there's something that isn't covered here or in a different guide, feel free to join the [KotOR Speedrunning Discord](https://discord.gg/6WpNfRZ).  The community is pretty friendly and always willing to help!
 
 ## How These Guides are Organized
 

--- a/kotor2/Route Guides/All Planets Unrestricted.md
+++ b/kotor2/Route Guides/All Planets Unrestricted.md
@@ -6,7 +6,7 @@ Written by [Redmage08](https://www.speedrun.com/users/Redmage08) and [R4NG3](htt
 
 This route defeats Darth Traya on Malachor V as fast as possible;  Timing begins upon clicking "PLAY" after character creation and ends on the last hit on Traya.  A load-removal tool is available for LiveSplit thanks to the community; times are sorted based on load-removed times, since load times vary significantly in this game, and saving is frequent.  This guide will cover the detailed route of the run.
 
-If you have additional questions, you can check out the [KotOR Speedrunning Discord](http://discord.gg/Q2uPRVu) There's a bunch of friendly folks there willing to answer questions!
+If you have additional questions, you can check out the [KotOR Speedrunning Discord](https://discord.gg/6WpNfRZ) There's a bunch of friendly folks there willing to answer questions!
 
 **Table of Contents:**
 - [Unrestricted Ruleset](#unrestricted-ruleset)
@@ -34,7 +34,7 @@ All glitches are allowed in Unrestricted; however, all KotOR speedruns ban the f
 
 - Learn how to swap abilities easily. Shift +# swaps the ability. (e.g shift+1 swaps from Critical Strike to Flurry etc. Shift+4 swaps force powers)
 - Watch someone's PB video while going through the notes! This is very important to fundamentally understand the run and how it flows, and learn possible tricks to make your run much faster and smoother.
-- Ask the [Discord](http://discord.gg/Q2uPRVu) questions you have, that’s the fastest way to get an answer!
+- Ask the [Discord](https://discord.gg/6WpNfRZ) questions you have, that’s the fastest way to get an answer!
 - Once you understand the fundamentals from these notes, make your own copy of the notes and modify them to your own use. These notes are made detailed for a new player, and once you become more experienced you will need less of the detail in your notes.
 - Remember to have fun!
 

--- a/kotor2/Route Guides/Any% No Dev Tools.md
+++ b/kotor2/Route Guides/Any% No Dev Tools.md
@@ -9,7 +9,7 @@ redirect_from:
 
 This route defeats Darth Traya on Malachor V as fast as possible without the use of Dev Tools.  Timing begins upon clicking "PLAY" after character creation and ends on reaching Traya's last conversation.  A load-remover and autosplitter tool is available for LiveSplit thanks to glasnonck, Lane, the_kovic, and Xero; times are sorted based on load-removed times, since load times vary significantly in this game, and saving is frequent.  This guide will cover the character build for the run, as well as a detailed route.
 
-Finally, if you have additional questions, you can check out the [KotOR Speedrunning Discord](http://discord.gg/Q2uPRVu).  There's a bunch of friendly folks there willing to answer questions!
+Finally, if you have additional questions, you can check out the [KotOR Speedrunning Discord](https://discord.gg/6WpNfRZ).  There's a bunch of friendly folks there willing to answer questions!
 
 **Table of Contents**
 - [NDT Ruleset](#ndt-ruleset)

--- a/kotor2/Route Guides/Any% Unrestricted.md
+++ b/kotor2/Route Guides/Any% Unrestricted.md
@@ -10,7 +10,7 @@ This route defeats Darth Traya on Malachor V as fast as possible.  Timing begins
 
 ***IMPORTANT NOTE:*** This route makes heavy use of [Forward Hotshots](<../Major Glitches/Hotshot#forward-hotshots>) and [Dev](<../Dev Tools/3C-FD>) [Tools](<../Dev Tools/Dev Character>), and thus only works on the Steam/Aspyr versions of KotOR II.  Legacy versions (including the CD version) will crash whenever a [Forward Hotshot](<../Major Glitches/Hotshot#forward-hotshots>) is used.  If you wish to speedrun the legacy versions of KotOR II, see the guide for Any% No Dev Tools.
 
-Finally, if you have additional questions, you can check out the [KotOR Speedrunning Discord](http://discord.gg/Q2uPRVu).  There's a bunch of friendly folks there willing to answer questions!
+Finally, if you have additional questions, you can check out the [KotOR Speedrunning Discord](https://discord.gg/6WpNfRZ).  There's a bunch of friendly folks there willing to answer questions!
 
 **Table of Contents**
 - [Unrestricted Ruleset](#unrestricted-ruleset)

--- a/kotor2/index.md
+++ b/kotor2/index.md
@@ -11,7 +11,7 @@ Welcome to the KotOR II Speedrunning Guides! Here you'll find a wealth of inform
 ## New to KotOR Speedrunning?
 
 If you're just beginning your KotOR speedrun journey, the following links will help you get started:
-- The [KotOR Speedrunning Discord](http://discord.gg/Q2uPRVu) is the place for all speedy KotOR discussion! We're a helpful community and always excited to see new runners.
+- The [KotOR Speedrunning Discord](https://discord.gg/6WpNfRZ) is the place for all speedy KotOR discussion! We're a helpful community and always excited to see new runners.
 - Our [Getting Started with KotOR Speedrunning](Getting%20Started) guide can help with basic questions, as well as the right settings for your game to streamline the speedrunning process.
 
 ## Route Guides
@@ -48,7 +48,7 @@ Glitch guides are split into three types:
 
 Here's some useful external links that can be helpful for KotOR II speedrunning.
 
-- [KotOR Speedrunning Discord](http://discord.gg/Q2uPRVu)
+- [KotOR Speedrunning Discord](https://discord.gg/6WpNfRZ)
 - [Leaderboards](https://www.speedrun.com/kotor2)
 - [Walkmesh Visualizer](https://github.com/glasnonck/WalkmeshVisualizer) by [glasnonck](https://www.speedrun.com/users/glasnonck)
 - [Bingo and Randomizer Downloads](https://www.speedrun.com/kotor2/resources) (Bingo by [30Cents](https://www.speedrun.com/users/30Cents), Randomizer by [Lane](https://www.speedrun.com/users/Lane))
@@ -80,4 +80,4 @@ Here's some useful external links that can be helpful for KotOR II speedrunning.
 
 This guide repository is community owned and maintained.  If you would like to contribute a guide, make a correction to an existing guide, or help edit this repository, feel free to make a pull request.  Each guide has a convenient <img src="/assets/images/github.svg" alt="GitHub Logo" width="16" height="16">  link at the top that leads to the source file for ease of access.
 
-Contact [Lane](https://www.speedrun.com/users/Lane), [indykenobi](https://www.speedrun.com/users/indykenobi), or another moderator on the [KotOR Speedrunning Discord](http://discord.gg/Q2uPRVu) if you have any questions.
+Contact [Lane](https://www.speedrun.com/users/Lane), [indykenobi](https://www.speedrun.com/users/indykenobi), or another moderator on the [KotOR Speedrunning Discord](https://discord.gg/6WpNfRZ) if you have any questions.


### PR DESCRIPTION
Looks like discord updated their invite scheme to use https, so a lot of the older http invite links are becoming stale for user-agents that enforce https.
I'm refreshing our discord invite in a few places I can think of, though keep this in mind if someone has trouble joining
